### PR TITLE
[WIP] Add ability to install custom JS module loaders.

### DIFF
--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/commonjs/CommonJSResolution.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/commonjs/CommonJSResolution.java
@@ -59,6 +59,7 @@ import com.oracle.truffle.js.builtins.GlobalBuiltins;
 import com.oracle.truffle.js.lang.JavaScriptLanguage;
 import com.oracle.truffle.js.runtime.Errors;
 import com.oracle.truffle.js.runtime.JSArguments;
+import com.oracle.truffle.js.runtime.JSEngine;
 import com.oracle.truffle.js.runtime.JSRealm;
 import com.oracle.truffle.js.runtime.Strings;
 import com.oracle.truffle.js.runtime.builtins.JSFunction;
@@ -66,6 +67,7 @@ import com.oracle.truffle.js.runtime.builtins.JSFunctionObject;
 import com.oracle.truffle.js.runtime.objects.JSDynamicObject;
 import com.oracle.truffle.js.runtime.objects.JSObject;
 import com.oracle.truffle.js.runtime.objects.Undefined;
+import static com.oracle.truffle.js.runtime.JSContextOptions.ModuleLoaderFactoryMode.HANDLER;
 
 public final class CommonJSResolution {
 

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/commonjs/NpmCompatibleESModuleLoader.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/builtins/commonjs/NpmCompatibleESModuleLoader.java
@@ -86,7 +86,7 @@ import com.oracle.truffle.js.runtime.objects.Null;
 import com.oracle.truffle.js.runtime.objects.ScriptOrModule;
 import com.oracle.truffle.js.runtime.objects.Undefined;
 
-public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
+public class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
 
     private static final URI TryCommonJS = URI.create("custom:///try-common-js-token");
     private static final URI TryCustomESM = URI.create("custom:///try-custom-esm-token");
@@ -105,7 +105,7 @@ public final class NpmCompatibleESModuleLoader extends DefaultESModuleLoader {
         return new NpmCompatibleESModuleLoader(realm);
     }
 
-    private NpmCompatibleESModuleLoader(JSRealm realm) {
+    protected NpmCompatibleESModuleLoader(JSRealm realm) {
         super(realm);
     }
 

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/CommonJSResolverHook.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/CommonJSResolverHook.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -40,62 +40,27 @@
  */
 package com.oracle.truffle.js.runtime;
 
-import java.util.Optional;
-import java.util.ServiceLoader;
+import com.oracle.truffle.api.TruffleFile;
 
-import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.TruffleLanguage;
-import com.oracle.truffle.js.lang.JavaScriptLanguage;
-
-public final class JSEngine {
-    private static final JSEngine INSTANCE = new JSEngine();
-
-    @CompilerDirectives.CompilationFinal
-    private static volatile JSModuleLoaderFactory MODULE_LOADER_FACTORY = null;
-
-    @CompilerDirectives.CompilationFinal
-    private static volatile CommonJSResolverHook CJS_RESOLVER_HOOK = null;
-
-    private final Evaluator parser;
-
-    private JSEngine() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        this.parser = ServiceLoader.load(Evaluator.class, classLoader).iterator().next();
-    }
-
-    public static JSEngine getInstance() {
-        return INSTANCE;
-    }
-
-    public Evaluator getEvaluator() {
-        return parser;
-    }
-
-    public Evaluator getParser() {
-        return parser;
-    }
-
-    private JSContext createContext(JavaScriptLanguage language, TruffleLanguage.Env env) {
-        return JSContext.createContext(parser, language, env);
-    }
-
-    public static void setModuleLoaderFactory(JSModuleLoaderFactory factory) {
-        MODULE_LOADER_FACTORY = factory;
-    }
-
-    public static void setCjsResolverHook(CommonJSResolverHook hook) {
-        CJS_RESOLVER_HOOK = hook;
-    }
-
-    public static JSModuleLoaderFactory getModuleLoaderFactory() {
-        return MODULE_LOADER_FACTORY;
-    }
-
-    public static CommonJSResolverHook getCjsResolverHook() {
-        return CJS_RESOLVER_HOOK;
-    }
-
-    public static JSContext createJSContext(JavaScriptLanguage language, TruffleLanguage.Env env) {
-        return JSEngine.getInstance().createContext(language, env);
-    }
+/**
+ * Allows GraalJs users to hook into the JavaScript CJS loading process.
+ */
+public interface CommonJSResolverHook {
+    /**
+     * Resolve a CommonJS module identifier to a file.
+     *
+     * <p>Return types which are valid include:
+     * <ul>
+     *     <li>{@link TruffleFile}: Will be interpreted as normal (i.e. as a CJS file)</li>
+     *     <li>Guest-compatible value: Returned as the module itself, without evaluation</li>
+     * </ul>
+     * </p>
+     *
+     * @param realm            the realm in which the module is being resolved
+     * @param moduleIdentifier the CommonJS module identifier
+     * @param entryPath        the path of the module that is importing the module
+     * @return Optional wrapping the type which should be returned for this module implementation; supported types
+     *   are listed above.
+     */
+    Object resolveModule(JSRealm realm, String moduleIdentifier, TruffleFile entryPath);
 }

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContextOptions.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSContextOptions.java
@@ -617,6 +617,25 @@ public final class JSContextOptions {
     public static final OptionKey<UnhandledRejectionsTrackingMode> UNHANDLED_REJECTIONS = new OptionKey<>(UnhandledRejectionsTrackingMode.NONE);
     @CompilationFinal private UnhandledRejectionsTrackingMode unhandledRejectionsMode;
 
+    public enum ModuleLoaderFactoryMode {
+        DEFAULT,
+        HANDLER;
+
+        @Override
+        public String toString() {
+            return name().toLowerCase(Locale.ENGLISH);
+        }
+    }
+
+    public static final String MODULE_LOADER_FACTORY_NAME = JS_OPTION_PREFIX + "module-loader-factory";
+
+    @Option(name = MODULE_LOADER_FACTORY_NAME, category = OptionCategory.USER, stability = OptionStability.EXPERIMENTAL, sandbox = SandboxPolicy.TRUSTED, help = """
+                    Configure a factory for overriding the JavaScript module loader. Accepted values: \
+                    'default', default behavior applies for CommonJS and ESM. \
+                    'handler', the handler function set with JSEngine.setModuleLoaderFactory will be called to satisfy CJS or ESM imports.""") //
+    public static final OptionKey<ModuleLoaderFactoryMode> MODULE_LOADER_FACTORY_MODE = new OptionKey<>(ModuleLoaderFactoryMode.DEFAULT);
+    @CompilationFinal private ModuleLoaderFactoryMode moduleLoaderFactoryMode;
+
     public static final String OPERATOR_OVERLOADING_NAME = JS_OPTION_PREFIX + "operator-overloading";
     @Option(name = OPERATOR_OVERLOADING_NAME, category = OptionCategory.USER, help = "Enable operator overloading") //
     public static final OptionKey<Boolean> OPERATOR_OVERLOADING = new OptionKey<>(false);
@@ -774,6 +793,7 @@ public final class JSContextOptions {
         this.useUTCForLegacyDates = USE_UTC_FOR_LEGACY_DATES.hasBeenSet(optionValues) ? readBooleanOption(USE_UTC_FOR_LEGACY_DATES) : !v8CompatibilityMode;
         this.webAssembly = readBooleanOption(WEBASSEMBLY);
         this.unhandledRejectionsMode = readUnhandledRejectionsMode();
+        this.moduleLoaderFactoryMode = readModuleLoaderFactoryMode();
         this.newSetMethods = readBooleanOption(NEW_SET_METHODS);
         this.atomicsWaitAsync = ATOMICS_WAIT_ASYNC.hasBeenSet(optionValues) ? readBooleanOption(ATOMICS_WAIT_ASYNC) : getEcmaScriptVersion() >= JSConfig.ECMAScript2024;
         this.asyncIteratorHelpers = getEcmaScriptVersion() >= JSConfig.ECMAScript2018 && readBooleanOption(ASYNC_ITERATOR_HELPERS);
@@ -802,6 +822,10 @@ public final class JSContextOptions {
 
     private UnhandledRejectionsTrackingMode readUnhandledRejectionsMode() {
         return UNHANDLED_REJECTIONS.getValue(optionValues);
+    }
+
+    private ModuleLoaderFactoryMode readModuleLoaderFactoryMode() {
+        return MODULE_LOADER_FACTORY_MODE.getValue(optionValues);
     }
 
     private boolean readBooleanOption(OptionKey<Boolean> key) {
@@ -1269,5 +1293,9 @@ public final class JSContextOptions {
 
     public short getFrequencyBasedPropertyCacheLimit() {
         return frequencyBasedPropertyCacheLimit;
+    }
+
+    public ModuleLoaderFactoryMode getModuleLoaderFactoryMode() {
+        return moduleLoaderFactoryMode;
     }
 }

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSModuleLoaderFactory.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSModuleLoaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -40,62 +40,17 @@
  */
 package com.oracle.truffle.js.runtime;
 
-import java.util.Optional;
-import java.util.ServiceLoader;
+import com.oracle.truffle.js.runtime.objects.JSModuleLoader;
 
-import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.TruffleLanguage;
-import com.oracle.truffle.js.lang.JavaScriptLanguage;
-
-public final class JSEngine {
-    private static final JSEngine INSTANCE = new JSEngine();
-
-    @CompilerDirectives.CompilationFinal
-    private static volatile JSModuleLoaderFactory MODULE_LOADER_FACTORY = null;
-
-    @CompilerDirectives.CompilationFinal
-    private static volatile CommonJSResolverHook CJS_RESOLVER_HOOK = null;
-
-    private final Evaluator parser;
-
-    private JSEngine() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        this.parser = ServiceLoader.load(Evaluator.class, classLoader).iterator().next();
-    }
-
-    public static JSEngine getInstance() {
-        return INSTANCE;
-    }
-
-    public Evaluator getEvaluator() {
-        return parser;
-    }
-
-    public Evaluator getParser() {
-        return parser;
-    }
-
-    private JSContext createContext(JavaScriptLanguage language, TruffleLanguage.Env env) {
-        return JSContext.createContext(parser, language, env);
-    }
-
-    public static void setModuleLoaderFactory(JSModuleLoaderFactory factory) {
-        MODULE_LOADER_FACTORY = factory;
-    }
-
-    public static void setCjsResolverHook(CommonJSResolverHook hook) {
-        CJS_RESOLVER_HOOK = hook;
-    }
-
-    public static JSModuleLoaderFactory getModuleLoaderFactory() {
-        return MODULE_LOADER_FACTORY;
-    }
-
-    public static CommonJSResolverHook getCjsResolverHook() {
-        return CJS_RESOLVER_HOOK;
-    }
-
-    public static JSContext createJSContext(JavaScriptLanguage language, TruffleLanguage.Env env) {
-        return JSEngine.getInstance().createContext(language, env);
-    }
+/**
+ * Allows GraalJs users to hook into the JavaScript ESM loading process.
+ */
+public interface JSModuleLoaderFactory {
+    /**
+     * Create an instance of the JavaScript module loader.
+     *
+     * @param realm JavaScript realm which intends to own this loader.
+     * @return Loader instance.
+     */
+    JSModuleLoader createLoader(JSRealm realm);
 }

--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSRealm.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/JSRealm.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.SplittableRandom;
 import java.util.WeakHashMap;
 
@@ -2975,12 +2976,33 @@ public class JSRealm {
     @TruffleBoundary
     private synchronized void createModuleLoader() {
         if (moduleLoader == null) {
-            if (getContextOptions().isCommonJSRequire()) {
-                moduleLoader = NpmCompatibleESModuleLoader.create(this);
-            } else {
-                moduleLoader = DefaultESModuleLoader.create(this);
+            JSModuleLoader loader = null;
+            switch (getContextOptions().getModuleLoaderFactoryMode()) {
+                case HANDLER -> loader = loadCustomModuleLoaderOrFallBack();
+                case DEFAULT -> loader = createStandardModuleLoader(this);
             }
+            assert loader != null;
+            moduleLoader = loader;
         }
+    }
+
+    private JSModuleLoader loadCustomModuleLoaderOrFallBack() {
+        JSModuleLoaderFactory fac = JSEngine.getModuleLoaderFactory();
+        if (fac == null) {
+            return createStandardModuleLoader(this);
+        }
+        var loader = fac.createLoader(this);
+        if (loader == null) {
+            return createStandardModuleLoader(this);
+        }
+        return loader;
+    }
+
+    private static JSModuleLoader createStandardModuleLoader(JSRealm realm) {
+        if (realm.getContextOptions().isCommonJSRequire()) {
+            return NpmCompatibleESModuleLoader.create(realm);
+        }
+        return DefaultESModuleLoader.create(realm);
     }
 
     public final JSAgent getAgent() {


### PR DESCRIPTION
- Adds `JSModuleLoaderFactory` interface for ESM loader hook.
- Adds `CommonJSResolverHook` interface for CJS resolver hook.
- Adds `js.module-loader-factory=handler` setting to enable.
- Adjusts `JSEngine` to retain the installed factory and/or resolver.
- Adjusts `JSRealm` to use `JSEngine` to create the module loader.
- Adjusts `NpmCompatibleESModuleLoader` to be extensible.
- Adjusts `CommonJSResolution` to use the resolver hook if present.

Relates to oracle/graal#9177
Relates to elide-dev/elide#1227
