### PR TITLE
Fix ClassCastException for eraYear without era on non-ISO calendars

### DIFF
--- a/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/util/TemporalUtil.java
+++ b/graal-js/src/com.oracle.truffle.js/src/com/oracle/truffle/js/runtime/util/TemporalUtil.java
@@ -3445,7 +3445,8 @@ public final class TemporalUtil {
                 Object eraYear = JSObject.get(fields, ERA_YEAR);
                 boolean eraSet = (era != Undefined.instance);
                 boolean eraYearSet = (eraYear != Undefined.instance);
-                if (eraYearSet && cal instanceof IslamicCalendar && Strings.equals(IntlUtil.BH, (TruffleString) era)) {
+                // Require era set before casting it below; eraYear without era falls through to the TypeError (spec).
+                if (eraSet && eraYearSet && cal instanceof IslamicCalendar && Strings.equals(IntlUtil.BH, (TruffleString) era)) {
                     eraYear = 1 - ((Number) eraYear).intValue();
                     JSObject.set(fields, ERA_YEAR, eraYear);
                 }


### PR DESCRIPTION
`TemporalUtil.calendarResolveFields` cast `era` to `TruffleString` in the Islamic-BH special case *before* the era/eraYear mutual-exclusion check. When `eraYear` is provided without `era` on a non-ISO calendar, `era` is `Nullish`, so the cast raised an internal `ClassCastException` that crossed the guest boundary as a guest-visible exception, instead of the spec-mandated `TypeError`.

## Fix

Guard the cast with `eraSet` so that `eraYear` without `era` short-circuits past the Islamic-BH special case and falls through to the existing `"Both era and eraYear should be set"` check, which throws `TypeError` per spec. One-line change plus a comment; no behavior change on the valid era+eraYear path.

## Verification

- All 60 `test262 intl402/Temporal/{PlainDate,PlainDateTime,PlainYearMonth,ZonedDateTime}/prototype/with/mutually-exclusive-fields-*` tests pass (15 calendars x 4 types), with no crashes and no assertion failures.
- The reported reproducer (`islamic-tbla` calendar, `.with({ eraYear: 1 })`) now throws `TypeError` instead of `ClassCastException`.
